### PR TITLE
fix potential problems when using two or more graph layers

### DIFF
--- a/modules/embedding_module.py
+++ b/modules/embedding_module.py
@@ -123,7 +123,7 @@ class GraphEmbedding(EmbeddingModule):
       neighbors = neighbors.flatten()
       neighbor_embeddings = self.compute_embedding(memory,
                                                    neighbors,
-                                                   edge_times.flatten(),
+                                                   np.repeat(timestamps, n_neighbors),
                                                    n_layers=n_layers - 1,
                                                    n_neighbors=n_neighbors)
 

--- a/modules/embedding_module.py
+++ b/modules/embedding_module.py
@@ -101,6 +101,12 @@ class GraphEmbedding(EmbeddingModule):
       return source_node_features
     else:
 
+      source_node_conv_embeddings = self.compute_embedding(memory,
+                                                           source_nodes,
+                                                           timestamps,
+                                                           n_layers=n_layers - 1,
+                                                           n_neighbors=n_neighbors)
+
       neighbors, edge_idxs, edge_times = self.neighbor_finder.get_temporal_neighbor(
         source_nodes,
         timestamps,
@@ -117,7 +123,7 @@ class GraphEmbedding(EmbeddingModule):
       neighbors = neighbors.flatten()
       neighbor_embeddings = self.compute_embedding(memory,
                                                    neighbors,
-                                                   np.repeat(timestamps, n_neighbors),
+                                                   edge_times.flatten(),
                                                    n_layers=n_layers - 1,
                                                    n_neighbors=n_neighbors)
 
@@ -129,7 +135,7 @@ class GraphEmbedding(EmbeddingModule):
 
       mask = neighbors_torch == 0
 
-      source_embedding = self.aggregate(n_layers, source_node_features,
+      source_embedding = self.aggregate(n_layers, source_node_conv_embeddings,
                                         source_nodes_time_embedding,
                                         neighbor_embeddings,
                                         edge_time_embeddings,


### PR DESCRIPTION
Hi, @emalgorithm,

I have fixed the potential problems when the model tends to use two or more graph layers. Moreover, when computing `neighbor_embeddings`, we need to use `edge_times` as the temporal information instead of `timestamps` (at line 126 in embedding_module.py), which is also revised in this PR. 

Please also kindly note our [recent work](https://arxiv.org/abs/2303.13047) has also reimplemented and integrated the wonderful model TGN in a unified dynamic graph learning library [here](https://github.com/yule-BUAA/DyGLib). 

If there are any problems, welcome to contact me.

Best,

Le Yu
