### PR TITLE
Fix issue where memory update at end may raise an exception when processing non-bipartite graphs

### DIFF
--- a/model/tgn.py
+++ b/model/tgn.py
@@ -178,12 +178,12 @@ class TGN(torch.nn.Module):
                                                                               source_nodes,
                                                                               source_node_embedding,
                                                                               edge_times, edge_idxs)
-      if self.memory_update_at_start:
-        self.memory.store_raw_messages(unique_sources, source_id_to_messages)
-        self.memory.store_raw_messages(unique_destinations, destination_id_to_messages)
-      else:
-        self.update_memory(unique_sources, source_id_to_messages)
-        self.update_memory(unique_destinations, destination_id_to_messages)
+
+      self.memory.store_raw_messages(unique_sources, source_id_to_messages)
+      self.memory.store_raw_messages(unique_destinations, destination_id_to_messages)
+
+      if not self.memory_update_at_start:
+        self.get_updated_memory(list(range(self.n_nodes)), self.memory.messages)
 
       if self.dyrep:
         source_node_embedding = memory[source_nodes]

--- a/model/tgn.py
+++ b/model/tgn.py
@@ -183,7 +183,10 @@ class TGN(torch.nn.Module):
       self.memory.store_raw_messages(unique_destinations, destination_id_to_messages)
 
       if not self.memory_update_at_start:
-        self.get_updated_memory(list(range(self.n_nodes)), self.memory.messages)
+          unique_node_ids = np.unique(np.concatenate((unique_sources, unique_destinations)))
+          self.update_memory(unique_node_ids,
+                             self.memory.messages)
+          self.memory.clear_messages(unique_node_ids)
 
       if self.dyrep:
         source_node_embedding = memory[source_nodes]


### PR DESCRIPTION
This pull request fixes issue #29.

Instead of updating the memory separately for sources and destinations, both sets of nodes are updated at once, similar to the `update_at_start` strategy